### PR TITLE
Fix Three.js deprecation notices for missing targets in certain methods

### DIFF
--- a/src/dem-node.ts
+++ b/src/dem-node.ts
@@ -1,4 +1,4 @@
-import { Box3, Vector2 } from 'three';
+import { Box3, Vector2, Vector3 } from 'three';
 
 export class DEMNode {
   level: number;
@@ -71,7 +71,8 @@ export class DEMNode {
   }
 
   uv(position: Vector2): [number, number] {
-    const boxSize = this.box.getSize();
+    const boxSize = new Vector3();
+    this.box.getSize(boxSize);
 
     const u = (position.x - this.box.min.x) / boxSize.x;
     const v = (position.y - this.box.min.y) / boxSize.y;

--- a/src/point-cloud-octree-geometry-node.ts
+++ b/src/point-cloud-octree-geometry-node.ts
@@ -59,7 +59,7 @@ export class PointCloudOctreeGeometryNode extends EventDispatcher implements IPo
     this.pcoGeometry = pcoGeometry;
     this.boundingBox = boundingBox;
     this.tightBoundingBox = boundingBox.clone();
-    this.boundingSphere = boundingBox.getBoundingSphere();
+    this.boundingSphere = boundingBox.getBoundingSphere(new Sphere());
   }
 
   /**


### PR DESCRIPTION
Box3.getSize()
Box3.getBoundingSphere()
Box3.getCenter()

Along the way replaced a couple a few for loops to use the more concise for-of syntax which Typescript converts to a normal loop.