### PR TITLE
chore: remove wasm2js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@pnext/three-loader",
       "version": "0.5.6",
       "license": "MIT",
-      "dependencies": {
-        "wasm2js": "^0.2.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
@@ -12143,6 +12140,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15773,18 +15771,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/wasm2js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wasm2js/-/wasm2js-0.2.0.tgz",
-      "integrity": "sha512-nQVER3bUF9mMdQxtUZS1rW7r3goy6+TZz+FqmILJLrPRASn/2K15yc1lNWyYLh9A/TkD+l7c22aMcpTCLr+ApA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "~1.2.0"
-      },
-      "bin": {
-        "wasm2js": "bin/wasm2js"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "release": "standard-version",
     "prepare": "husky"
   },
-  "dependencies": {
-    "wasm2js": "^0.2.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "three": "~0.160.0"
   },


### PR DESCRIPTION
If I understand the code correctly, wasm2js is used as a compilation step to transform the Splat sorter file from a WASM file into a base64 string. This is done manually, and not at runtime. Therefore the library should not be part of the project's dependencies. 

Let me know if I am missing something, thanks!