### PR TITLE
feat(gaussians): separate the harmonics from mobile

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_MIN_NODE_PIXEL_SIZE = 200;
 export const DEFAULT_MIN_POINT_SIZE = 2;
 export const DEFAULT_PICK_WINDOW_SIZE = 15;
 export const DEFAULT_POINT_BUDGET = 1_000_000;
+export const MAX_AMOUNT_OF_SPLATS = 4000000;
 export const MAX_LOADS_TO_GPU = 3;
 export const MAX_NUM_NODES_LOADING = 4;
 export const PERSPECTIVE_CAMERA = 'PerspectiveCamera';

--- a/src/materials/shaders/splats.vert
+++ b/src/materials/shaders/splats.vert
@@ -10,6 +10,7 @@ uniform vec2 basisViewport;
 uniform float harmonicsDegree;
 uniform bool renderIds;
 uniform bool adaptiveSize;
+uniform bool renderLoD;
 
 uniform sampler2D covarianceTexture0;
 uniform sampler2D covarianceTexture1;
@@ -255,11 +256,13 @@ void main() {
     //Get the adaptive size
     float renderScale = 1.;
 
+    float attenuation = getPointSizeAttenuation( instancePosition, vnStart, float(level) );
+
     if(adaptiveSize) {
 
         float slope = tan(fov / 2.0);
 	    float projFactor =  -0.5 * screenHeight / (slope * viewCenter.z);
-        float worldSpaceSize = 2.0 * spacing / getPointSizeAttenuation( instancePosition, vnStart, float(level) );
+        float worldSpaceSize = 2.0 * spacing / attenuation;
         renderScale = worldSpaceSize * projFactor;
 
         //the splats should be at least the default size.
@@ -407,51 +410,51 @@ void main() {
     
     vColor.rgb = clamp(vColor.rgb, vec3(0.), vec3(1.));
 
-/*
-    //Test the LOD
-    int LOD = int(getLOD( instancePosition, int(vnStart), float(level) ));
-    switch ( LOD ) {
-        case 0:
-            vColor.rgb = vec3(1., 0., 0.);
-        break;
-        case 1:
-            vColor.rgb = vec3(0., 1., 0.);
-        break;
-        case 2:
-            vColor.rgb = vec3(0., 0., 1.);
-        break;
-        case 3:
-            vColor.rgb = vec3(1., 0., 1.);
-        break;
-        case 4:
-            vColor.rgb = vec3(1., 1., 0.);
-        break;
-        case 5:
-            vColor.rgb = vec3(0., 1., 1.);
-        break;
-        case 6:
-            vColor.rgb = vec3(0.5, 0., 0.);
-        break;
-        case 7:
-            vColor.rgb = vec3(0., 0.5, 0.);
-        break;
-        case 8:
-            vColor.rgb = vec3(0.0, 0., 0.5);
-        break;
-        case 9:
-            vColor.rgb = vec3(0.5, 0., 0.5);
-        break;
-        case 10:
-            vColor.rgb = vec3(0.5, 0.5, 0.0);
-        break;
-        case 11:
-            vColor.rgb = vec3(0.0, 0.5, 0.5);
-        break;
-        case 12:
-            vColor.rgb = vec3(1., 1., 1.);
-        break;
+    if(renderLoD) {
+        //Test the LOD
+        int LOD = int(getLOD( instancePosition, int(vnStart), float(level) ));
+        switch ( LOD ) {
+            case 0:
+                vColor.rgb = vec3(1., 0., 0.);
+            break;
+            case 1:
+                vColor.rgb = vec3(0., 1., 0.);
+            break;
+            case 2:
+                vColor.rgb = vec3(0., 0., 1.);
+            break;
+            case 3:
+                vColor.rgb = vec3(1., 0., 1.);
+            break;
+            case 4:
+                vColor.rgb = vec3(1., 1., 0.);
+            break;
+            case 5:
+                vColor.rgb = vec3(0., 1., 1.);
+            break;
+            case 6:
+                vColor.rgb = vec3(0.5, 0., 0.);
+            break;
+            case 7:
+                vColor.rgb = vec3(0., 0.5, 0.);
+            break;
+            case 8:
+                vColor.rgb = vec3(0.0, 0., 0.5);
+            break;
+            case 9:
+                vColor.rgb = vec3(0.5, 0., 0.5);
+            break;
+            case 10:
+                vColor.rgb = vec3(0.5, 0.5, 0.0);
+            break;
+            case 11:
+                vColor.rgb = vec3(0.0, 0.5, 0.5);
+            break;
+            case 12:
+                vColor.rgb = vec3(1., 1., 1.);
+            break;
+        }
     }
-    */
 
 	vOpacity = colorData.a;
 }

--- a/src/point-cloud-octree.ts
+++ b/src/point-cloud-octree.ts
@@ -11,7 +11,7 @@ import {
   Mesh,
   BufferGeometry,
 } from 'three';
-import { DEFAULT_MIN_NODE_PIXEL_SIZE } from './constants';
+import { DEFAULT_MIN_NODE_PIXEL_SIZE, MAX_AMOUNT_OF_SPLATS } from './constants';
 import { OctreeGeometry } from './loading2/octree-geometry';
 import { PointCloudMaterial, PointSizeType } from './materials';
 import { PointCloudOctreeNode } from './point-cloud-octree-node';
@@ -26,9 +26,6 @@ import {
 } from './types';
 import { computeTransformedBoundingBox } from './utils/bounds';
 import { SplatsMesh } from './splats-mesh';
-
-const MAX_SPLATS_RENDERED = 4000000;
-const MAX_SPLATS_RENDERED_MOBILE = 500000;
 
 export class PointCloudOctree extends PointCloudTree {
   potree: IPotree;
@@ -58,14 +55,14 @@ export class PointCloudOctree extends PointCloudTree {
   private lastUpdateViewPos = new Vector3();
   private updateViewOffset = new Vector3();
   private loadHarmonics: boolean = false;
-  private splatsMobile: boolean = false;
+  private maxAmountOfSplats: number = MAX_AMOUNT_OF_SPLATS;
 
   constructor(
     potree: IPotree,
     pcoGeometry: PCOGeometry,
     material?: PointCloudMaterial,
     loadHarmonics: boolean = false,
-    splatsMobile: boolean = false,
+    maxAmountOfSplats: number = MAX_AMOUNT_OF_SPLATS,
   ) {
     super();
 
@@ -76,7 +73,7 @@ export class PointCloudOctree extends PointCloudTree {
     this.boundingBox = pcoGeometry.boundingBox;
     this.boundingSphere = this.boundingBox.getBoundingSphere(new Sphere());
     this.loadHarmonics = loadHarmonics;
-    this.splatsMobile = splatsMobile;
+    this.maxAmountOfSplats = maxAmountOfSplats;
     this.position.copy(pcoGeometry.offset);
     this.updateMatrix();
 
@@ -175,10 +172,7 @@ export class PointCloudOctree extends PointCloudTree {
 
       //Initialise the splats mesh if the nodes contain splats information
       if (this.renderAsSplats) {
-        this.splatsMesh.initialize(
-          this.splatsMobile ? MAX_SPLATS_RENDERED_MOBILE : MAX_SPLATS_RENDERED,
-          this.loadHarmonics,
-        );
+        this.splatsMesh.initialize(this.maxAmountOfSplats, this.loadHarmonics);
         this.add(this.splatsMesh);
       }
     }
@@ -303,5 +297,9 @@ export class PointCloudOctree extends PointCloudTree {
     return this.visibleGeometry.length === 0
       ? 0
       : this.visibleNodes.length / this.visibleGeometry.length;
+  }
+
+  get maxAmountOfSplatsToRender() {
+    return this.maxAmountOfSplats;
   }
 }

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_POINT_BUDGET,
   MAX_LOADS_TO_GPU,
   MAX_NUM_NODES_LOADING,
+  MAX_AMOUNT_OF_SPLATS,
   PERSPECTIVE_CAMERA,
 } from './constants';
 import { FEATURES } from './features';
@@ -79,10 +80,11 @@ export class Potree implements IPotree {
     getUrl: GetUrlFn,
     xhrRequest = (input: RequestInfo, init?: RequestInit) => fetch(input, init),
     loadHarmonics: boolean = false,
-    splatsMobile: boolean = false,
+    maxAmountOfSplats: number = MAX_AMOUNT_OF_SPLATS,
   ): Promise<PointCloudOctree> {
     return this.loadGeometry(url, getUrl, xhrRequest, loadHarmonics).then(
-      (geometry) => new PointCloudOctree(this, geometry, undefined, loadHarmonics, splatsMobile),
+      (geometry) =>
+        new PointCloudOctree(this, geometry, undefined, loadHarmonics, maxAmountOfSplats),
     );
   }
 

--- a/src/splats-mesh.ts
+++ b/src/splats-mesh.ts
@@ -140,6 +140,7 @@ export class SplatsMesh extends Object3D {
           renderIds: { value: false },
           debugMode: { value: false },
           renderOnlyHarmonics: { value: false },
+          renderLoD: { value: false },
           adaptiveSize: { value: false },
           harmonicsScale: { value: 4 },
           octreeSize: { value: 0 },

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export interface IPotree {
     getUrl: GetUrlFn,
     xhrRequest?: XhrRequest,
     loadHarmonics?: boolean,
-    splatsMobile?: boolean,
+    maxAmountOfSplats?: number,
   ): Promise<PointCloudOctree>;
 
   updatePointClouds(


### PR DESCRIPTION
Decouple the harmonics loading from the mobile mode, so the splats can be loaded without harmonics in desktop.
