### PR TITLE
Use getEffectiveFOV for perspective camera

### DIFF
--- a/src/materials/point-cloud-material.ts
+++ b/src/materials/point-cloud-material.ts
@@ -610,7 +610,7 @@ export class PointCloudMaterial extends RawShaderMaterial {
     const pixelRatio = renderer.getPixelRatio();
 
     if (camera.type === PERSPECTIVE_CAMERA) {
-      this.fov = (camera as PerspectiveCamera).fov * (Math.PI / 180);
+      this.fov = (camera as PerspectiveCamera).getEffectiveFOV() * (Math.PI / 180);
     } else {
       this.fov = Math.PI / 2; // will result in slope = 1 in the shader
     }

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -289,7 +289,7 @@ export class Potree implements IPotree {
 
       if (camera.type === PERSPECTIVE_CAMERA) {
         const perspective = camera as PerspectiveCamera;
-        const fov = (perspective.fov * Math.PI) / 180.0;
+        const fov = (perspective.getEffectiveFOV() * Math.PI) / 180.0;
         const slope = Math.tan(fov / 2.0);
         projectionFactor = halfHeight / (slope * distance);
       } else {

--- a/src/potree.ts
+++ b/src/potree.ts
@@ -294,7 +294,7 @@ export class Potree implements IPotree {
         projectionFactor = halfHeight / (slope * distance);
       } else {
         const orthographic = camera as OrthographicCamera;
-        projectionFactor = (2 * halfHeight) / (orthographic.top - orthographic.bottom);
+        projectionFactor = (2 * halfHeight * orthographic.zoom) / (orthographic.top - orthographic.bottom);
       }
 
       const screenPixelRadius = radius * projectionFactor;


### PR DESCRIPTION
Effective FOV can be changed by PerspectiveCamera's [zoom](https://threejs.org/docs/#api/en/cameras/PerspectiveCamera.zoom) property. This should be considered when updating material fov.