### PR TITLE
refactor: webpack config throws errors about potree.worker.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,11 +18,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.worker\.js$/,
-        loader: 'worker-loader',
-        options: { inline: 'no-fallback' },
-      },
-      {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel-loader',


### PR DESCRIPTION
Cleanup webpack config, as we no longer have this worker in the codebase. Removing noise.